### PR TITLE
Ensure sample function usable without models and fix package imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest configuration for ensuring the `src` directory is on ``sys.path``.
+
+This allows the test suite to import the package without installing it.
+"""
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SRC = ROOT / "src"
+if SRC.exists():
+    sys.path.insert(0, str(SRC))
+

--- a/src/autora/__init__.py
+++ b/src/autora/__init__.py
@@ -1,0 +1,4 @@
+"""Top level package for autora."""
+
+__all__ = []
+

--- a/src/autora/experimentalist/__init__.py
+++ b/src/autora/experimentalist/__init__.py
@@ -1,0 +1,4 @@
+"""Experimentalist module for autora."""
+
+__all__ = []
+

--- a/src/autora/experimentalist/autora_experimentalist_example/__init__.py
+++ b/src/autora/experimentalist/autora_experimentalist_example/__init__.py
@@ -3,11 +3,12 @@ import numpy as np
 import pandas as pd
 from typing import Union, List
 
+
 def sample(
         conditions: Union[pd.DataFrame, np.ndarray],
-        models: List,
-        reference_conditions: Union[pd.DataFrame, np.ndarray],
         num_samples: int = 1,
+        models: List | None = None,
+        reference_conditions: Union[pd.DataFrame, np.ndarray, None] = None,
         random_state: Union[int, None] = None,
         ) -> pd.DataFrame:
     """
@@ -17,6 +18,8 @@ def sample(
     - Diversity: farthest-first on a shortlist
     - NEW: cap candidate/reference sizes to avoid O(N*M) memory blowups; novelty via NearestNeighbors.
     """
+    models = models or []
+
     # ----------------- Tunables for scale -----------------
     # Max candidates to score each iteration (subset of pool)
     #CAND_CAP = 5000                      # try 5k; lower if you still see crashes


### PR DESCRIPTION
## Summary
- Allow `sample` to be called with just conditions and num_samples by adding defaults for models and reference conditions
- Provide package `__init__` files and a pytest `conftest.py` so `autora.experimentalist.autora_experimentalist_example` can be imported during tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ac693160832997fa409132cef219